### PR TITLE
fixed opacity bug, set renderOrder to -1

### DIFF
--- a/src/Core/MapObject.ts
+++ b/src/Core/MapObject.ts
@@ -629,7 +629,7 @@ class MapObject {
             }
             this.mesh.position.set(this.position.x, this.position.y, this
                 .position.z);
-            this.mesh.renderOrder = 9999;
+            this.mesh.renderOrder = -1;
             this.boundingBoxSettings = objCollision[1][0];
             if (this.boundingBoxSettings) {
                 if (this.currentStateInstance.graphicID === 0) {

--- a/src/Core/MapPortion.ts
+++ b/src/Core/MapPortion.ts
@@ -185,7 +185,7 @@ class MapPortion {
         if (!geometry.isEmpty()) {
             geometry.updateAttributes();
             this.staticFloorsMesh = new THREE.Mesh(geometry, material);
-            this.staticFloorsMesh.renderOrder = 0;
+            this.staticFloorsMesh.renderOrder = -1;
             if (Scene.Map.current.mapProperties.isSunLight) {
                 this.staticFloorsMesh.receiveShadow = true;
                 this.staticFloorsMesh.castShadow = true;
@@ -321,7 +321,7 @@ class MapPortion {
         if (!staticGeometry.isEmpty()) {
             staticGeometry.updateAttributes();
             this.staticSpritesMesh = new THREE.Mesh(staticGeometry, material);
-            this.staticSpritesMesh.renderOrder = 999;
+            this.staticSpritesMesh.renderOrder = -1;
             if (Scene.Map.current.mapProperties.isSunLight) {
                 this.staticSpritesMesh.receiveShadow = true;
                 this.staticSpritesMesh.castShadow = true;
@@ -332,7 +332,7 @@ class MapPortion {
         if (!faceGeometry.isEmpty()) {
             faceGeometry.updateAttributes();
             this.faceSpritesMesh = new THREE.Mesh(faceGeometry, material);
-            this.faceSpritesMesh.renderOrder = 999;
+            this.faceSpritesMesh.renderOrder = -1;
             if (Scene.Map.current.mapProperties.isSunLight) {
                 this.faceSpritesMesh.castShadow = true;
                 this.faceSpritesMesh.receiveShadow = true;
@@ -584,7 +584,7 @@ class MapPortion {
                     geometry.updateAttributes();
                     mesh = new THREE.Mesh(geometry, obj.material);
                     this.staticObjects3DList.push(mesh);
-                    mesh.renderOrder = 999;
+                    mesh.renderOrder = -1;
                     if (Scene.Map.current.mapProperties.isSunLight) {
                         mesh.receiveShadow = true;
                         mesh.castShadow = true;

--- a/src/Scene/Map.ts
+++ b/src/Scene/Map.ts
@@ -901,7 +901,7 @@ class Map extends Base {
         points.position.set(Scene.Map.current.camera.target.position.x, Scene
             .Map.current.camera.target.position.y, Scene.Map.current.camera.target
             .position.z)
-        points.renderOrder = 1000;
+        points.renderOrder = -1;
         this.scene.add(points);
         if (current) {
             this.weatherPoints = points;

--- a/src/System/MapProperties.ts
+++ b/src/System/MapProperties.ts
@@ -166,6 +166,7 @@ class MapProperties extends Base {
         this.skyboxGeometry = new THREE.BoxGeometry(size, size, size);
         this.skyboxMesh = new THREE.Mesh(this.skyboxGeometry, Datas.Systems
             .getSkybox(this.backgroundSkyboxID.getValue()).createTextures());
+		this.skyboxMesh.renderOrder = -1;
         Scene.Map.current.scene.add(this.skyboxMesh);
     }
 


### PR DESCRIPTION
Opacity bug can be fixed by setting opaque meshes render order to -1 and dynamically changing it to 0 for transparent meshes