### PR TITLE
Update SaveLoadGame.ts

### DIFF
--- a/src/Scene/SaveLoadGame.ts
+++ b/src/Scene/SaveLoadGame.ts
@@ -39,8 +39,9 @@ class SaveLoadGame extends Base {
         let currentGame = Game.current;
         for (let i = 1; i <= Datas.Systems.saveSlots; i++) {
             this.gamesDatas.push(null);
-            Game.current = new Game(i);
-            await Game.current.load();
+            const newGame = new Game(i);
+            await newGame.load();
+			Game.current = newGame;
             this.initializeGame(Game.current);
         }
         Game.current = currentGame;


### PR DESCRIPTION
fixed a very specific bug that would crash the game upon opening the save menu directly from the map while having dynamic options enabled, such as move camera on block view set to a variable